### PR TITLE
[937] Enable Azure RBAC authentication to AKS

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -32,7 +32,7 @@ runs:
         terraform_version: 1.5.4
         terraform_wrapper: false
 
-    - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
       with:
         azure-credentials: ${{ inputs.azure-credentials }}
 
@@ -43,7 +43,6 @@ runs:
         make ci ${{ inputs.environment }} terraform-apply
         cd terraform/application && echo "url=$(terraform output -raw url)" >> $GITHUB_OUTPUT
       env:
-        TF_VAR_azure_sp_credentials_json: ${{ inputs.azure-credentials }}
         TF_VAR_statuscake_api_token: ${{ inputs.statuscake-api-token }}
         DOCKER_IMAGE: ${{ inputs.docker-image }}
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
@@ -56,6 +55,7 @@ runs:
       if: ${{ inputs.pull-request-number != '' }}
       shell: bash
       run: |
-        az aks get-credentials --resource-group s189t01-tsc-ts-rg --name s189t01-tsc-test-aks
+        make ci review get-cluster-credentials
         kubectl exec -n cpd-development deployment/cpd-tsh-review-${{ inputs.pull-request-number }} -- sh -c "cd /app && /usr/local/bin/bundle exec rails db:seed"
-
+      env:
+        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}

--- a/.github/workflows/aks_destroy_review.yml
+++ b/.github/workflows/aks_destroy_review.yml
@@ -38,7 +38,7 @@ jobs:
             echo "TF_STATE_EXISTS=true" >> $GITHUB_ENV
           fi
 
-      - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         if: env.TF_STATE_EXISTS == 'true'
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
@@ -49,7 +49,6 @@ jobs:
         shell: bash
         run: make ci review terraform-destroy
         env:
-          TF_VAR_azure_sp_credentials_json: ${{ secrets.AZURE_CREDENTIALS }}
           TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
           DOCKER_IMAGE: "ghcr.io/dfe-digital/early-careers-framework:no-tag"
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/aks_destroy_review.yml
+++ b/.github/workflows/aks_destroy_review.yml
@@ -30,8 +30,8 @@ jobs:
 
           echo "TF_STATE_FILE=$state_file_name" >> $GITHUB_ENV
 
-          state_file_status=$(az storage blob list -c cpdecf-tfstate \
-            --account-name "s189t01cpdecftfstatervsa" \
+          state_file_status=$(az storage blob list -c terraform-state \
+            --account-name "s189t01cpdtshrvtfsa" \
             --prefix $state_file_name --query "[].name" -o tsv)
 
           if [ -n "$state_file_status" ]; then
@@ -56,5 +56,5 @@ jobs:
       - name: Delete Terraform state file
         if: env.TF_STATE_EXISTS == 'true'
         run: |
-          az storage blob delete -c cpdecf-tfstate --name ${{ env.TF_STATE_FILE }} \
-            --account-name "s189t01cpdecftfstatervsa"
+          az storage blob delete -c terraform-state --name ${{ env.TF_STATE_FILE }} \
+            --account-name "s189t01cpdtshrvtfsa"

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ production-cluster:
 
 get-cluster-credentials: set-azure-account
 	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}
+	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)
 
 aks-console: get-cluster-credentials
 	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ terraform-plan: terraform-init
 terraform-apply: terraform-init
 	terraform -chdir=terraform/application apply -var-file "config/${CONFIG}.tfvars.json" ${AUTO_APPROVE}
 
+terraform-destroy: terraform-init
+	terraform -chdir=terraform/application destroy -var-file "config/${CONFIG}.tfvars.json" ${AUTO_APPROVE}
+
 set-what-if:
 	$(eval WHAT_IF=--what-if)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TERRAFILE_VERSION=0.8
 ARM_TEMPLATE_TAG=1.1.10
 RG_TAGS={"Product" : "Find a teaching school hub"}
 REGION=UK South
-SERVICE_NAME=teaching-school-hub-finder
+SERVICE_NAME=cpd-tsh
 SERVICE_SHORT=cpdtsh
 
 help:

--- a/terraform/application/.terraform.lock.hcl
+++ b/terraform/application/.terraform.lock.hcl
@@ -1,11 +1,35 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/eppo/environment" {
+  version     = "1.3.5"
+  constraints = "1.3.5"
+  hashes = [
+    "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
+    "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
+    "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
+    "zh:12ca5162286b80b7f46bd013ae2007641132d201af12bc6adb872f9a0ff85b7a",
+    "zh:2991085432bd4dc718aadfb37b2cdb6201ef73a8a0e5661411f46d9ec782e678",
+    "zh:2a8f6801266f89b816ebfdb441411e53f4cf1e0278e853715fb561946ad5a575",
+    "zh:8783a8dc846d3e71b38ca470066f506dde8040f149402f0d348e5dca7f012909",
+    "zh:8bc8f61e496e96c81c46e1aa59bf2155b6acc80db1ea462f2ddd665748fcda7f",
+    "zh:95fb102fecceb3a5b44dbe9fbe262494a0abdb6805addf1286c5d92cd4b0f779",
+    "zh:a158837ec561c161d3c47068e30bca341e5e4c7abff7fa72b9522438b85af4ac",
+    "zh:a738a7b2e953ee8059f9e68d48ae954175d001a5480f29e22d717bee9fd93f7f",
+    "zh:bac4b3a38eed35c91269cd008ad88862f47be99474de85e9a2efcce6564e0c24",
+    "zh:cd56a12eef3515fa5a5845d550be2f67989c8e65563e8fa9f5060666c0728a7c",
+    "zh:e3e895bc8b557b36bfa03f251df429aa0fba068f4c7ef0ed6ac551b7cba9ff86",
+    "zh:e959a9e826e3c33242bf4492ee12e5f8be023cf2461702c43d1833c4a8516232",
+    "zh:f41d9d60b205e6d536881e4af7bb9fc85ae90858bfddf695f95fbd68e01e0ad3",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.62.1"
   constraints = "3.62.1"
   hashes = [
     "h1:3dG3gNv/w2Sad5EOIWSG7JesKKtRhIiQJzgWOdqpaos=",
+    "h1:50KMNmLOMfkfnV8iqsozNHXHI+j2QDwwdfBcRZ4/I7k=",
     "zh:0fa21ac98474f3a2aeab1191628735ddf1fdb0767f935e8b0f7e259a335773cd",
     "zh:45ca710ffc39d194e0a29ca6983117a180302f3e1babb425257a23a1f38bb974",
     "zh:481fd2ace1cf52ebae940ec8c66d025d2582af3aaf67340b6afbfa7a19b86864",
@@ -25,6 +49,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.21.1"
   constraints = "2.21.1"
   hashes = [
+    "h1:2spGoBcGDQ/Csc23bddCfM21zyKx3PONoiqRgmuChnM=",
     "h1:gP8IU3gFfXYRfGZr5Qws9JryZsOGsluAVpiAoZW7eo0=",
     "zh:156a437d7edd6813e9cb7bdff16ebce28cec08b07ba1b0f5e9cec029a217bc27",
     "zh:1a21c255d8099e303560e252579c54e99b5f24f2efde772c7e39502c62472605",
@@ -42,20 +67,20 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version = "3.5.1"
+  version = "3.6.0"
   hashes = [
-    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
-    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
-    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
-    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
-    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
-    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
-    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
-    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
-    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
-    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
-    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
   ]
 }

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -1,6 +1,5 @@
 locals {
   environment  = "${var.environment}${var.app_suffix}"
-  service_name = "cpd-tsh"
   domain       = var.environment == "review" ? "cpd-tsh-${local.environment}-web.test.teacherservices.cloud" : var.domain
 }
 
@@ -8,13 +7,12 @@ module "application_configuration" {
   source = "./vendor/modules/aks//aks/application_configuration"
 
   namespace              = var.namespace
-  environment           = local.environment
+  environment            = local.environment
   azure_resource_prefix  = var.azure_resource_prefix
   service_short          = var.service_short
   config_short           = var.config_short
   secret_key_vault_short = "app"
 
-  # Delete for non rails apps
   is_rails_application = true
 
   config_variables = {
@@ -37,7 +35,7 @@ module "web_application" {
 
   namespace    = var.namespace
   environment  = local.environment
-  service_name = local.service_name
+  service_name = var.service_name
 
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -3,6 +3,5 @@
     "namespace": "cpd-development",
     "environment": "review",
     "deploy_azure_backing_services": false,
-    "enable_postgres_ssl" : false,
-    "command": ["/bin/sh", "-c", "bundle exec rails db:environment:set RAILS_ENV=review && RAILS_ENV=review bundle exec rails db:schema:load && RAILS_ENV=review bundle exec rails db:seed && bundle exec rails server -b 0.0.0.0"]
+    "enable_postgres_ssl" : false
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -4,7 +4,7 @@ module "postgres" {
   namespace                   = var.namespace
   environment                 = local.environment
   azure_resource_prefix       = var.azure_resource_prefix
-  service_name                = local.service_name
+  service_name                = var.service_name
   service_short               = var.service_short
   config_short                = var.config_short
   cluster_configuration_map   = module.cluster_data.configuration_map
@@ -25,7 +25,7 @@ module "redis-cache" {
   azure_resource_prefix     = var.azure_resource_prefix
   service_short             = var.service_short
   config_short              = var.config_short
-  service_name              = local.service_name
+  service_name              = var.service_name
   cluster_configuration_map = module.cluster_data.configuration_map
   use_azure                 = var.deploy_azure_backing_services
   azure_enable_monitoring   = var.enable_monitoring

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -23,10 +23,6 @@ provider "azurerm" {
   features {}
 
   skip_provider_registration = true
-  subscription_id            = try(local.azure_credentials.subscriptionId, null)
-  client_id                  = try(local.azure_credentials.clientId, null)
-  client_secret              = try(local.azure_credentials.clientSecret, null)
-  tenant_id                  = try(local.azure_credentials.tenantId, null)
 }
 
 provider "kubernetes" {
@@ -34,4 +30,13 @@ provider "kubernetes" {
   client_certificate     = module.cluster_data.kubernetes_client_certificate
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -7,10 +7,6 @@ variable "namespace" {
 variable "environment" {
   description = "Name of the deployed environment in AKS"
 }
-variable "azure_credentials_json" {
-  default     = null
-  description = "JSON containing the service principal authentication key when running in automation"
-}
 variable "azure_resource_prefix" {
   description = "Standard resource prefix. Usually s189t01 (test) or s189p01 (production)"
 }
@@ -62,7 +58,5 @@ variable "app_suffix" {
 }
 
 locals {
-  azure_credentials = try(jsondecode(var.azure_credentials_json), null)
-
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 }


### PR DESCRIPTION
### Context

Ticket: https://trello.com/c/3m8PNLG6

The AKS clusters will be migrated to Azure RBAC and the authentication need to change.

### Changes proposed in this pull request
- Use kubelogin to enable Azure RBAC
- Remove azure credentials for terraform as they are provided by set-kubelogin-environment
