### PR TITLE
[1647] Enable statuscake monitoring

### DIFF
--- a/terraform/application/.terraform.lock.hcl
+++ b/terraform/application/.terraform.lock.hcl
@@ -84,3 +84,26 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
   ]
 }
+
+provider "registry.terraform.io/statuscakedev/statuscake" {
+  version     = "2.1.0"
+  constraints = "2.1.0"
+  hashes = [
+    "h1:GI/6fNXTYwAcpvo4iES2VbrLJaJg8Lp4TdiQBxyhgTo=",
+    "zh:00cd46ce1502f0df61eb1f1aa6cac07399f20e48c89033dd53314b733762252d",
+    "zh:0fddb98d450ae9ad8daa25b1fec5c1e8c6c6487560d52da57b0e71e2531025e9",
+    "zh:1132ba7edd59a6514a02edb1efac2ca93a79a1831d4cd4d2923330b750aebe2d",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:20c8c16eb2fa16604fbbc0b828f2f74a92a47336e77f7f8cd89cc8f9754cebad",
+    "zh:20d0471e43f3817f52932fec2a7a8f58cdec79c20ac3d6766024516a237cb9cd",
+    "zh:36ba9b954c6316ae71d727cb11daf0aa5274bfd845882a22eb12ebbfb1503d14",
+    "zh:59827eae7136112ea9a45f83fc6bc2807e0980472d27a9faef5ffc329a09c42e",
+    "zh:8095d102d4d9899017cb5a518e3f4e76f6ea635e6181889b0d2e26ae0c35a847",
+    "zh:89c45f1f416f30dd95812f322dd13137612a7a57382b446ed2f6c4593e6c8156",
+    "zh:89f69ab96ae0a70c8270deb40e5a4d84e6c4cfc20c7f1671339c45ef8a5daad2",
+    "zh:a6bda1fc94bb7b47adb81cde18057037ab0febb3f0272c76addfec35726b72f1",
+    "zh:b04dedbe459ba39fe82b4a5d71d23f80ac2b11bb5686fdbd92a9118e128bee8d",
+    "zh:c31851ebcb6fdf745c31900a319fc5e0422019e49ef03406e61f3bcaa61ffc05",
+    "zh:e08c785ec8703a60362b9f4e66e3b6b1b8b0c8867c0ac87590bab3bd5ab5b3f1",
+  ]
+}

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -2,5 +2,7 @@
     "cluster": "production",
     "namespace": "cpd-production",
     "environment": "production",
-    "enable_postgres_backup_storage" : true
+    "enable_postgres_backup_storage" : true,
+    "external_url": "https://find-a-teaching-school-hub.education.gov.uk/healthcheck",
+    "enable_monitoring": true
 }

--- a/terraform/application/statuscake.tf
+++ b/terraform/application/statuscake.tf
@@ -1,10 +1,10 @@
-//module "statuscake" {
-//  count = var.enable_monitoring ? 1 : 0
-//
-//  source = "./vendor/modules/aks//monitoring/statuscake"
-//
-//  uptime_urls = compact([module.web_application.probe_url, var.external_url])
-//  ssl_urls    = compact([var.external_url])
-//
-//  contact_groups = var.statuscake_contact_groups
-//}
+module "statuscake" {
+  count = var.enable_monitoring ? 1 : 0
+
+  source = "./vendor/modules/aks/monitoring/statuscake"
+
+  uptime_urls = compact([module.web_application.probe_url, var.external_url])
+  ssl_urls    = compact([var.external_url])
+
+  contact_groups = var.statuscake_contact_groups
+}

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -9,10 +9,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.21.1"
     }
-    // statuscake = {
-    //   source  = "StatusCakeDev/statuscake"
-    //   version = "2.1.0"
-    // }
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "2.1.0"
+    }
   }
   backend "azurerm" {
     container_name = "terraform-state"
@@ -39,4 +39,8 @@ provider "kubernetes" {
       args        = module.cluster_data.kubelogin_args
     }
   }
+}
+
+provider "statuscake" {
+  api_token = try(module.infrastructure_secrets.map.STATUSCAKE-API-TOKEN, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 }


### PR DESCRIPTION
### Context
Create uptime and SSL certificate checks via terraform to replace the manually created ones

Ticket: https://trello.com/c/9WQqXVn8

### Changes proposed in this pull request
Configure the statuscake provider , create uptime and SSL certificate checks via terraform

### Guidance to review
Run terraform-plan in production