### PR TITLE
Update config to enable merge queues

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -1,7 +1,7 @@
 name: "Deploy"
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:
@@ -193,7 +193,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:


### PR DESCRIPTION
* concurreny group switched from `github.ref` so that subsequent merges don't cancel in-progress deployments
* don't build docker images when the event name is `merge_group` because these aren't 'real' branches, but they're phantom branches used in the merge queue to make sure future (actual) merges will build cleanly
