### PR TITLE
Change CODEOWNERS to NPQ team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Lockyy @leoapost @peteryates @shjohnson @BroiSatse @javier-npq @slawosz
+* @DFE-Digital/npq-cpd


### PR DESCRIPTION
The previous list was way out of date, using the npq-cpd team is easier to maintain.
