### PR TITLE
Add and configure `rails_semantic_logger`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'geocoder'
 gem "pg", "~> 1.1"
 gem "puma", "~> 6.4"
 gem "rails", "~> 7.1.3"
+gem "rails_semantic_logger"
 gem "rgeo"
 gem "rgeo-geojson"
 gem "rgeo-proj4"
@@ -38,6 +39,7 @@ group :test do
 end
 
 group :test, :development do
+  gem "amazing_print"
   gem "byebug"
   gem "dotenv-rails"
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    amazing_print (1.6.0)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.7)
@@ -233,6 +234,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails_semantic_logger (4.14.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.13)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -318,6 +323,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    semantic_logger (4.15.0)
+      concurrent-ruby (~> 1.0)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
     stringio (3.1.0)
@@ -360,6 +367,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-postgis-adapter
+  amazing_print
   bootsnap
   brakeman
   bundler (~> 2.4)
@@ -380,6 +388,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 6.4)
   rails (~> 7.1.3)
+  rails_semantic_logger
   rgeo
   rgeo-geojson
   rgeo-proj4

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,19 +63,21 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.rails_semantic_logger.add_file_appender = false
+
+    $stdout.sync = true
+
+    config.semantic_logger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: :json)
   end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Don't log SQL
+  config.active_record.logger = nil
 end


### PR DESCRIPTION
### Context

We're about to start shipping logs to logit.io again so want to change the log format to JSON with [the Rails semantic Logger](https://logger.rocketjob.io/rails.html).

To ease development this PR also introduces `amazing_print` which colourises the logs in development.


### Testing with `RAILS_ENV=production`

```
RAILS_LOG_TO_STDOUT=1 ORDNANCE_SURVEY_API_KEY=abc123 RAILS_ENV=production be rails s
=> Booting Puma
=> Rails 7.1.3.2 application starting in production
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 6.4.2 (ruby 3.3.0-p0) ("The Eagle of Durango")
*  Min threads: 5
*  Max threads: 5
*  Environment: production
*          PID: 2260079
* Listening on http://0.0.0.0:3000
Use Ctrl-C to stop
{"host":"graphia-workstation","application":"Semantic Logger","environment":"production","timestamp":"2024-05-31T11:12:45.575770Z","level":"warn","level_index":3,"pid":2260079,"thread":"puma srv tp 002","tags":["0ad3d641-e8e1-472a-b733-24a018c80f44"],"name":"Rails","message":"hello, this should appear in JSON"}
{"host":"graphia-workstation","application":"Semantic Logger","environment":"production","timestamp":"2024-05-31T11:12:45.585925Z","level":"info","level_index":2,"pid":2260079,"thread":"puma srv tp 002","duration_ms":10.514479994773865,"duration":"10.5ms","tags":["0ad3d641-e8e1-472a-b733-24a018c80f44"],"name":"SearchController","message":"Completed #form","payload":{"controller":"SearchController","action":"form","format":"HTML","method":"GET","path":"/","status":200,"view_runtime":8.81,"db_runtime":0.0,"allocations":14038,"status_message":"OK"}}
^C- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2024-05-31 12:12:52 +0100 ===
- Goodbye!
Exiting
```

### Testing in the `development` env

Making sure the output is colourised and easy to read.

![image](https://github.com/DFE-Digital/teaching-school-hub-finder/assets/128088/42383f81-7eee-4961-ba21-a56d52e1d261)

