### PR TITLE
Ignore dependabot prs when requesting reviews from team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 * @DFE-Digital/npq-cpd
+
+# Don't automatically assign reviewers on PRs that only modify these files,
+# as they are dependabot pull requests.
+Gemfile
+Gemfile.lock
+package.json
+yarn.lock


### PR DESCRIPTION
### Context

This includes js updates and gem updates. We might get the occasional ruby version update on the actions but it should be less noisy

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000

[Why are we making this change?]

### Changes proposed in this pull request

Ignore dependabot js and gem updates