### PR TITLE
Remove `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-* @DFE-Digital/npq-cpd
-
-# Don't automatically assign reviewers on PRs that only modify these files,
-# as they are dependabot pull requests.
-Gemfile
-Gemfile.lock
-package.json
-yarn.lock


### PR DESCRIPTION
This service is non-transactional, only has 2 pages and doesn't really change very often. CODEOWNERS is overkill for Dependabot bumps.
