### PR TITLE
update LA of YH10 to one that exists

### DIFF
--- a/db/data/hubs.csv
+++ b/db/data/hubs.csv
@@ -77,7 +77,7 @@ WM7,Haybridge Teaching School Hub,www.haybridgeteachingschoolhub.co.uk/,info@hay
 WM8,Manor Teaching School Hub,www.manorteachingschoolhub.com/,info@manorteachingschoolhub.com,01902 558 901,South Staffordshire;Walsall;Wolverhampton
 WM9,Arthur Terry Teaching School Hub - North Birmingham,www.arthurterryteachingschool.atlp.org.uk/,northbirminghamTSH@atlp.org.uk,0121 328 1128,Birmingham
 YH1,Exchange Teaching Hub,www.exchangeteachinghub.org.uk,info@exchangeteachinghub.org.uk,0345 145 0075,Barnsley;Doncaster
-YH10,Red Kite Teaching School Hub,www.redkitetsh.co.uk/,tsh@rklt.co.uk,01423 535 646,North Yorkshire West
+YH10,Red Kite Teaching School Hub,www.redkitetsh.co.uk/,tsh@rklt.co.uk,01423 535 646,North Yorkshire
 YH2,South Yorkshire Teaching Hub,www.southyorkshireteachinghub.org/,info@southyorkshireteachinghub.org,0114 235 7980,Rotherham;Sheffield
 YH3,Pathfinder Teaching School Hub,www.pathfinder-tsh.co.uk,info@tsh.pmat.academy,01904 806 900,North Yorkshire East;York
 YH4,DRET Teaching School Hub,www.dretteachingschoolhub.co.uk,teachingschoolhub@dret.co.uk,01472 602 000 ext 3060,North East Lincolnshire;North Lincolnshire


### PR DESCRIPTION
### Context

The hub.csv has an LA of "North Yorkshire West" for Red Kite Teaching School Hub - this LA does not exist.
If the data is reimported on production, then Red Kite Teaching School Hub will not appear in any results.

### Changes proposed in this pull request

Change LA for Red Kite from "North Yorkshire West" to "North Yorkshire". 
