### PR TITLE
[CPDNPQ-2932] Use correct node version for CI

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '16.20.0'
+          node-version: '20.15.1'
 
       - name: Update dependencies
         run: sudo apt-get update
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '16.20.0'
+          node-version: '20.15.1'
 
       - name: Set up ruby gem cache
         uses: actions/cache@v4
@@ -170,7 +170,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '16.20.0'
+          node-version: '20.15.1'
 
       - name: Set up ruby gem cache
         uses: actions/cache@v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 terraform 1.5.4
+nodejs 20.15.1


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2932](https://dfedigital.atlassian.net/browse/CPDNPQ-2932)

We are currently running CI against Node v16 but the docker images are using v20

### Changes proposed in this pull request

1. Bring CI into alignment with the NodeJS version used in the Docker image
