### PR TITLE
[CPDNPQ-2932] Prevent concurrent deploys

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -250,6 +250,7 @@ jobs:
 
   deploy_staging:
     name: Deploy staging
+    concurrency: deploy_app_staging
     needs: [docker, rspec, linting, brakeman]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
@@ -273,6 +274,7 @@ jobs:
 
   deploy_sandbox:
     name: Deploy sandbox
+    concurrency: deploy_app_sandbox
     needs: [deploy_staging]
     runs-on: ubuntu-latest
     environment:
@@ -295,6 +297,7 @@ jobs:
   deploy_production:
     name: Deploy production
     needs: [deploy_staging]
+    concurrency: deploy_app_production
     runs-on: ubuntu-latest
     environment:
       name: production


### PR DESCRIPTION
### Context

Ticket: `[CPDNPQ-2932](https://dfedigital.atlassian.net/browse/CPDNPQ-2932)

When we end up with multiple concurrent deployments, the later ones fail because of locking on the terraform statefile

### Changes proposed in this pull request

1. Use GitHubs concurrency option to wait for the the earlier deploy to the environment to complete 
