### PR TITLE
feat(2419):  CPDTSH - AKS containers run as non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,5 +64,12 @@ RUN apk add --no-cache libpq proj-dev yaml
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
+
+RUN chown appuser:appgroup /app/tmp
+
+# Switch to non-root user
+USER 10001
+
 CMD bundle exec rails db:migrate && \
     bundle exec rails server -b 0.0.0.0

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -43,6 +43,7 @@ module "web_application" {
 
   docker_image = var.docker_image
 
-  replicas     = var.app_replicas
-  enable_logit = var.enable_logit
+  replicas        = var.app_replicas
+  enable_logit    = var.enable_logit
+  run_as_non_root = var.run_as_non_root
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -68,6 +68,13 @@ variable "app_replicas" {
 
 variable "enable_logit" { default = false }
 
+variable "run_as_non_root" {
+  type        = bool
+  default     = true
+  description = "Whether to enforce that containers must run as non-root user"
+}
+
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 }
+


### PR DESCRIPTION
### Context

[Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000](https://trello.com/c/gChmWtQ5/2419-security-aks-containers-run-as-non-root-user-cpdtsh?filter=member:paulsenior26)

### Why are we making this change? 

- follow best practice for running containers securely on AKS hosts

### Changes proposed in this pull request

- add new non-root user and group
- chmod minimum required files to allow non-rot- user to run the app
- amend Dockerfile to run the app as the new non-root user

### What has been changed?
Dockerfile modified to setup a new user and group and run the container with them:-
https://github.com/DFE-Digital/teaching-school-hub-finder/pull/261/files

<img width="1312" height="154" alt="Screenshot from 2025-07-31 11-42-46" src="https://github.com/user-attachments/assets/f4d8da04-c549-4c38-8064-f564e6c1a5ed" />
