### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
         with:
           message: |
             Review app deployed to ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -31,7 +31,7 @@ jobs:
         snyk-token: ${{ secrets.SNYK_TOKEN }}
 
     - name: Notify slack on failure
-      uses: rtCamp/action-slack-notify@master
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at 2.3.3
       if: ${{ failure() }}
       with:
         SLACK_USERNAME: CI Deployment


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR