### PR TITLE
[NPQ-3637] use --ignore-scripts for all yarn installs

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -83,7 +83,7 @@ jobs:
           bundle install --jobs 4 --retry 3
 
       - name: Install yarn
-        run: npm install yarn -g
+        run: npm install yarn -g --ignore-scripts
 
       - name: Yarn cache
         id: yarn-cache
@@ -98,7 +98,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install node.js dependencies
-        run: yarn install
+        run: yarn install --ignore-scripts
 
       - name: Set up test database
         run: bin/rails db:create db:schema:load
@@ -148,7 +148,7 @@ jobs:
           bundle install --jobs 4 --retry 3
 
       - name: Install node.js dependencies
-        run: yarn install
+        run: yarn install --ignore-scripts
 
       - name: Run rubocop
         run: bundle exec rubocop --format clang --parallel

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN bundler -v && \
 
 # Install node packages defined in package.json
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --check-files
+RUN yarn install --frozen-lockfile --check-files --ignore-scripts
 
 # Copy all files to /app (except what is defined in .dockerignore)
 COPY . .

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,10 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+# these tasks are redefined in lib/tasks/yarn_overrides.rake to allow installing with --ignore-scripts
+Rake::Task["yarn:install"].clear
+Rake::Task["javascript:install"].clear
+Rake::Task["css:install"].clear
+
+load "lib/tasks/yarn_overrides.rake"

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies
-  system!('yarn')
+  system!("yarn install --ignore-scripts")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/lib/tasks/yarn_overrides.rake
+++ b/lib/tasks/yarn_overrides.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :javascript do
+  desc "overrides the default install task to allow installing with --ignore-scripts"
+  # rake task this is overriding can be found here: https://github.com/rails/jsbundling-rails/blob/v1.3.1/lib/tasks/jsbundling/build.rake#L28
+  task :install do # rubocop:disable Rails/RakeEnvironment
+    system("yarn install --ignore-scripts")
+  end
+end
+
+namespace :yarn do
+  desc "overrides the default install task to allow installing with --ignore-scripts"
+  # rake task this is overriding can be found here: https://github.com/rails/rails/blob/v8.0.4.1/railties/lib/rails/tasks/yarn.rake
+  task :install do # rubocop:disable Rails/RakeEnvironment
+    system("yarn install --no-progress --frozen-lockfile --ignore-scripts")
+  end
+end
+
+namespace :css do
+  desc "overrides the default install task to allow installing with --ignore-scripts"
+  # rake task this is overriding can be found here: https://github.com/rails/cssbundling-rails/blob/v1.4.3/lib/tasks/cssbundling/build.rake#L3
+  task :install do # rubocop:disable Rails/RakeEnvironment
+    system("yarn install --ignore-scripts")
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3637

### Changes proposed in this pull request

use `yarn install --ignore-scripts` everywhere we currently `yarn install`
