### PR TITLE
2683 - New GitHub action validate infra workflow

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -1,0 +1,43 @@
+name: Validate Infra
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: ${{ matrix.display }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display: AKS infrastructure
+            validation_plan: aks-infra
+            terraform_base: terraform/application
+          - display: Domains infrastructure
+            validation_plan: domains-infra
+            terraform_base: terraform/domains/infrastructure
+          - display: Domains environment
+            validation_plan: domains-env
+            terraform_base: terraform/domains/environment_domains
+
+    steps:
+      - name: Validate ${{ matrix.display }}
+        uses: DFE-Digital/github-actions/validate-infra@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          environment: production
+          terraform-base: ${{ matrix.terraform_base }}
+          validation-plan: ${{ matrix.validation_plan }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
+          docker-repo: true
+          service-name: teaching-school-hub-finder

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ terraform-init: composed-variables set-azure-account
 	$(eval export TF_VAR_docker_image=${DOCKER_IMAGE})
 
 terraform-plan: terraform-init
-	terraform -chdir=terraform/application plan -var-file "config/${CONFIG}.tfvars.json"
+	terraform -chdir=terraform/application plan ${DETAILED_EXITCODE} -var-file "config/${CONFIG}.tfvars.json"
 
 terraform-apply: terraform-init
 	terraform -chdir=terraform/application apply -var-file "config/${CONFIG}.tfvars.json" ${AUTO_APPROVE}
@@ -104,7 +104,7 @@ domains-infra-init: domains composed-variables set-azure-account
 		-backend-config=key=domains_infrastructure.tfstate
 
 domains-infra-plan: domains domains-infra-init  ## Terraform plan for DNS infrastructure (zone and front door. Usage: make domains-infra-plan
-	terraform -chdir=terraform/domains/infrastructure plan -var-file config/zones.tfvars.json
+	terraform -chdir=terraform/domains/infrastructure plan ${DETAILED_EXITCODE} -var-file config/zones.tfvars.json
 
 domains-infra-apply: domains domains-infra-init  ## Terraform apply for DNS infrastructure (zone and front door). Usage: make domains-infra-apply
 	terraform -chdir=terraform/domains/infrastructure apply -var-file config/zones.tfvars.json ${AUTO_APPROVE}
@@ -122,7 +122,7 @@ domains-destroy: domains-init  ## Terraform destroy for DNS environment domains.
 	terraform -chdir=terraform/domains/environment_domains destroy -var-file config/${CONFIG}.tfvars.json
 
 domains-plan: domains-init  ## Terraform plan for DNS environment domains. Usage: make development domains domains-plan
-	terraform -chdir=terraform/domains/environment_domains plan -var-file config/${CONFIG}.tfvars.json
+	terraform -chdir=terraform/domains/environment_domains plan ${DETAILED_EXITCODE} -var-file config/${CONFIG}.tfvars.json
 
 domains-apply: domains-init ## Terraform apply for DNS environment domains. Usage: make development domains domains-apply
 	terraform -chdir=terraform/domains/environment_domains apply -var-file config/${CONFIG}.tfvars.json ${AUTO_APPROVE}


### PR DESCRIPTION
### Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

Add a new GitHub action workflow validate-infrastructure.yml.
${DETAILED_EXITCODE} added to Terraform plan in Makefile.
TEAMS_WEBHOOK_URL_INFRA added as an Action repository secret.

### Guidance to review

Manually test changes by altering terraform/domains/environment_domains/config/production.tfvars.json **limit** and running locally the following command.
`make production domains-plan  CONFIRM_PRODUCTION=yes`
This will produce a Terraform update in place.

To validate the workflow once available. Make a test branch with a change to terraform/domains/environment_domains/config/production.tfvars.json **limit**. Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
