### PR TITLE
[BAU] Ignore cooldown for rails dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: daily
     time: "07:00"
+  cooldown:
+    default-days: 3
+    exclude:
+    - rails
   ignore:
     - dependency-name: "rails"
       update-types:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"#, cooldown: 7
+source "https://rubygems.org", cooldown: 3
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby file: ".ruby-version"


### PR DESCRIPTION
### Context

Ticket: BAU

We want to receive dependabot updates to the `rails` gem immediately in the event of security fixes

### Changes proposed in this pull request

1. Change the default cooldown when running bundler directly from 7 days to 3 days
2. Explicitly set the cooldown for ruby packages to 3 days
3. Exclude `rails` from the ruby package cooldown